### PR TITLE
Variable cleanup in Addons

### DIFF
--- a/mozprofile/mozprofile/addons.py
+++ b/mozprofile/mozprofile/addons.py
@@ -87,7 +87,6 @@ class AddonManager(object):
         Installs addons from a manifest
         filepath - path to the manifest of addons to install
         """
-        self.manifests.append(filepath)
         manifest = ManifestParser()
         manifest.read(filepath)
         addons = manifest.get()


### PR DESCRIPTION
noticed that there were some unused variables and my OCD got the better of me. Tests are still passing

(mozprofile)davidburns :: (var-cleanup|✔)  /mozilla/forks/mozbase/mozprofile>  py.test
========================================================= =========================================================  
platform darwin -- Python 2.6.6 -- pytest-2.2.3  
tests/test_preferences.py ......  
====================================================== 6 passed in 1.03 seconds =======================================================
