### PR TITLE
Bugfix and Feature for DeviceManagerADB

### DIFF
--- a/mozdevice/mozdevice/devicemanagerADB.py
+++ b/mozdevice/mozdevice/devicemanagerADB.py
@@ -25,11 +25,17 @@ class DeviceManagerADB(DeviceManager):
         packageName = 'org.mozilla.fennec_'
     self.Init(packageName)
 
+  def __del__(self):
+    if (self.host != None):
+      self.disconnectRemoteADB()
+
   def Init(self, packageName):
     # Initialization code that may fail: Catch exceptions here to allow
     # successful initialization even if, for example, adb is not installed.
     try:
       self.verifyADB()
+      if (self.host != None):
+        self.connectRemoteADB()
       self.verifyRunAs(packageName)
     except:
       self.useRunAs = False
@@ -62,6 +68,12 @@ class DeviceManagerADB(DeviceManager):
           print "restarting as root failed, but run-as available"
         else:
           print "restarting as root failed"
+
+  def connectRemoteADB(self):
+    self.checkCmd(["connect", self.host + ":" + str(self.port)])
+
+  def disconnectRemoteADB(self):
+    self.checkCmd(["disconnect", self.host + ":" + str(self.port)])
 
   # external function
   # returns:


### PR DESCRIPTION
Hi,

the following to commits

a) Fix a bug with run-as failure (e.g. due to non-debuggable package or buggy run-as
b) Add TCP/IP support for ADB (adb connect/disconnect), and use it automatically when host is specified.

Directly sending you pull requests as ctalbert told me I should just send you those to get them reviewed/integrated.

Cheers,

Chris
