### PR TITLE
Bug 711520 - Allows mozrunner to point to Mac binaries

### DIFF
--- a/mozrunner/mozrunner/runner.py
+++ b/mozrunner/mozrunner/runner.py
@@ -53,6 +53,9 @@ from utils import findInPath
 from mozprofile import *
 from mozprocess.processhandler import ProcessHandler
 
+if mozinfo.isMac:
+    from plistlib import readPlist
+
 package_metadata = get_metadata_from_egg('mozrunner')
 
 class Runner(object):
@@ -80,6 +83,12 @@ class Runner(object):
             raise Exception("Binary not specified")
         if not os.path.exists(self.binary):
             raise OSError("Binary path does not exist: %s" % self.binary)
+
+        # allow Mac binaries to be specified as an app bundle
+        if mozinfo.isMac and os.path.splitext(self.binary)[1] == '.app':
+            info = readPlist("%s/Contents/Info.plist" % self.binary)
+            self.binary = os.path.join(self.binary, "Contents/MacOS/%s" % 
+                                       info['CFBundleExecutable'])
 
         self.cmdargs = cmdargs or []
         _cmdargs = [i for i in self.cmdargs

--- a/mozrunner/setup.py
+++ b/mozrunner/setup.py
@@ -43,7 +43,7 @@ import sys
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = "mozrunner"
-PACKAGE_VERSION = "5.1"
+PACKAGE_VERSION = "5.2"
 
 desc = """Reliable start/stop/configuration of Mozilla Applications (Firefox, Thunderbird, etc.)"""
 # take description from README


### PR DESCRIPTION
This allows mozrunner to accept Mac app bundles, i.e. /Applications/Firefox.app is now a valid binary argument.
