### PR TITLE
Add timeouts for shell/checkCmd

### DIFF
--- a/mozdevice/mozdevice/devicemanager.py
+++ b/mozdevice/mozdevice/devicemanager.py
@@ -39,7 +39,7 @@ def abstractmethod(method):
 class DeviceManager:
 
   @abstractmethod
-  def shell(self, cmd, outputfile, env=None, cwd=None):
+  def shell(self, cmd, outputfile, env=None, cwd=None, timeout=None):
     """
     executes shell command on device
     returns:

--- a/mozdevice/mozdevice/devicemanagerSUT.py
+++ b/mozdevice/mozdevice/devicemanagerSUT.py
@@ -265,16 +265,16 @@ class DeviceManagerSUT(DeviceManager):
   # returns:
   # success: <return code>
   # failure: None
-  def shell(self, cmd, outputfile, env=None, cwd=None):
+  def shell(self, cmd, outputfile, env=None, cwd=None, timeout=None):
     cmdline = self._escapedCommandLine(cmd)
     if env:
       cmdline = '%s %s' % (self.formatEnvString(env), cmdline)
 
     try:
       if cwd:
-        self.sendCmds([{ 'cmd': 'execcwd %s %s' % (cwd, cmdline) }], outputfile)
+        self.sendCmds([{ 'cmd': 'execcwd %s %s' % (cwd, cmdline) }], outputfile, timeout)
       else:
-        self.sendCmds([{ 'cmd': 'exec su -c "%s"' % cmdline }], outputfile)
+        self.sendCmds([{ 'cmd': 'exec su -c "%s"' % cmdline }], outputfile, timeout)
     except AgentError:
       return None
 


### PR DESCRIPTION
I added the timeout parameter for the shell command in devicemanager.py, and full support for timeouts in devicemanagerADB.py. I've tested the checkCmd and shell commands against my pandaboard and it works as expected.

I don't really use devicemanagerSUT.py, so all I did was allow it to accept the timeout parameter, but it doesn't have support yet. If requested, I can get that working here too, but it's a bit of a detour.
