### PR TITLE
Bug 879960 - bump mozlog version number

### DIFF
--- a/mozlog/setup.py
+++ b/mozlog/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 
 PACKAGE_NAME = "mozlog"
-PACKAGE_VERSION = "1.1"
+PACKAGE_VERSION = "1.2"
 
 setup(name=PACKAGE_NAME,
       version=PACKAGE_VERSION,


### PR DESCRIPTION
Let's deploy a new version of mozlog for our python26 slaves.
