### PR TITLE
Bug 917550 - [mozprocess] ProcessHandler commandline attr broken

### DIFF
--- a/mozprocess/tests/test_mozprocess.py
+++ b/mozprocess/tests/test_mozprocess.py
@@ -136,6 +136,48 @@ class ProcTest(unittest.TestCase):
                               p.proc.returncode,
                               p.didTimeout)
 
+    def test_commandline_no_args(self):
+        """Command line is reported correctly when no arguments are specified"""
+        p = processhandler.ProcessHandler(self.proclaunch, cwd=here)
+        self.assertEqual(p.commandline, self.proclaunch)
+
+    def test_commandline_overspecified(self):
+        """Command line raises an exception when the arguments are specified ambiguously"""
+        err = None
+        try:
+            p = processhandler.ProcessHandler([self.proclaunch, "process_normal_finish.ini"],
+                                              args=["1", "2", "3"],
+                                              cwd=here)
+        except TypeError, e:
+            err = e
+
+        self.assertTrue(err)
+
+    def test_commandline_from_list(self):
+        """Command line is reported correctly when command and arguments are specified in a list"""
+        p = processhandler.ProcessHandler([self.proclaunch, "process_normal_finish.ini"],
+                                          cwd=here)
+        self.assertEqual(p.commandline, self.proclaunch + ' process_normal_finish.ini')
+
+    def test_commandline_over_specified(self):
+        """Command line raises an exception when the arguments are specified ambiguously"""
+        err = None
+        try:
+            p = processhandler.ProcessHandler([self.proclaunch, "process_normal_finish.ini"],
+                                              args=["1", "2", "3"],
+                                              cwd=here)
+        except TypeError, e:
+            err = e
+
+        self.assertTrue(err)
+
+    def test_commandline_from_args(self):
+        """Command line is reported correctly when arguments are specified in a dedicated list"""
+        p = processhandler.ProcessHandler(self.proclaunch,
+                                          args=["1", "2", "3"],
+                                          cwd=here)
+        self.assertEqual(p.commandline, self.proclaunch + ' 1 2 3')
+
     def test_process_wait(self):
         """Process is started runs to completion while we wait indefinitely"""
 


### PR DESCRIPTION
Consistently store `cmd` as a string and `args` as a list. Throw an
error when `args` are over-specified. Document the complete usage of the
`cmd` and `args` options.
