### PR TITLE
Bug 959040 - turn on WebRTC logging for Firefox OS emulator. r=ahal.

### DIFF
--- a/mozrunner/mozrunner/remote.py
+++ b/mozrunner/mozrunner/remote.py
@@ -106,6 +106,10 @@ class B2GRunner(RemoteRunner):
                      'MOZ_CRASHREPORTER_NO_REPORT': '1',
                      'MOZ_HIDE_RESULTS_TABLE': '1',
                      'MOZ_PROCESS_LOG': processLog,
+                     'NSPR_LOG_MODULES': 'signaling:5,mtransport:3',
+                     'R_LOG_LEVEL': '5',
+                     'R_LOG_DESTINATION': 'stderr',
+                     'R_LOG_VERBOSE': '1',
                      'NO_EM_RESTART': '1', }
         self.env.update(tmp_env)
         self.last_test = "automation"


### PR DESCRIPTION
Add environment variable for turning on WebRTC logging.

try result: https://tbpl.mozilla.org/?tree=Try&rev=cb82181e704b
